### PR TITLE
Order

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -13,7 +13,7 @@ class Admin::ItemsController < ApplicationController
 
   def edit
   end
-  
+
   def create
     @genres = Genre.all
     @item = Item.new(item_params)
@@ -23,13 +23,13 @@ class Admin::ItemsController < ApplicationController
     else
       render "admin/items/new"
     end
-  end 
-  
+  end
+
   def update
-  end 
-  
+  end
+
   private
   def item_params
     params.require(:item).permit(:name, :introduction, :price, :is_active, :item_image, :genre_id)
-  end 
+  end
 end

--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -1,8 +1,6 @@
 class Admin::OrderDetailsController < ApplicationController
   def update
-    @order = Order.find(params[:order_id])
-    @item = Item.find(params[:id])
-    @order_detail = OrderDetail.find_by(order_id: @order.id, item_id: @item.id)
+    @order_detail = OrderDetail.find(params[:id])
     @order_detail.update(order_detail_params)
     redirect_to admin_order_path(@order)
   end 

--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -2,9 +2,17 @@ class Admin::OrderDetailsController < ApplicationController
   def update
     @order_detail = OrderDetail.find(params[:id])
     @order_detail.update(order_detail_params)
-    redirect_to admin_order_path(@order)
-  end 
-  
+    order = @order_detail.order
+    #すべての商品の準備が出来たらオーダーステータスを発送準備中に変更
+    if order.order_details.count == order.order_details.where(production_status: 3).count
+      order.update(order_status: 3)
+    #入金確認が取れたら自動的に製作ステータスを製作待ちに変更
+    elsif @order_detail.production_status == "working"
+      order.update(order_status: 2)
+    end
+    redirect_to admin_order_path(@order_detail.order_id)
+  end
+
   private
   def order_detail_params
     params.require(:order_detail).permit(:production_status)

--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -1,4 +1,14 @@
 class Admin::OrderDetailsController < ApplicationController
   def update
+    @order = Order.find(params[:order_id])
+    @item = Item.find(params[:id])
+    @order_detail = OrderDetail.find_by(order_id: @order.id, item_id: @item.id)
+    @order_detail.update(order_detail_params)
+    redirect_to admin_order_path(@order)
   end 
+  
+  private
+  def order_detail_params
+    params.require(:order_detail).permit(:production_status)
+  end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,10 +1,23 @@
 class Admin::OrdersController < ApplicationController
   def index
+    @orders = Order.page(params[:page]).per(10)
   end
 
   def show
+    @order = Order.find(params[:id])
+    @order_customer_name = @order.customer.family_name + @order.customer.first_name
   end
   
   def update
-  end 
+    @order = Order.find(params[:id])
+    @order.update(order_params)
+    redirect_to admin_order_path(@order)
+  end
+  
+  private
+  
+  def order_params
+    params.require(:order).permit(:order_status)
+  end
+  
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,6 +1,6 @@
 class Admin::OrdersController < ApplicationController
   def index
-    @orders = Order.page(params[:page]).per(10)
+    @orders = Order.page(params[:page])
   end
 
   def show

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -7,17 +7,17 @@ class Admin::OrdersController < ApplicationController
     @order = Order.find(params[:id])
     @order_customer_name = @order.customer.family_name + @order.customer.first_name
   end
-  
+
   def update
     @order = Order.find(params[:id])
     @order.update(order_params)
     redirect_to admin_order_path(@order)
   end
-  
+
   private
-  
+
   def order_params
     params.require(:order).permit(:order_status)
   end
-  
+
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -6,11 +6,16 @@ class Admin::OrdersController < ApplicationController
   def show
     @order = Order.find(params[:id])
     @order_customer_name = @order.customer.family_name + @order.customer.first_name
+    @total = @order.order_details.inject(0) {|sum, order_detail| sum + order_detail.subtotal}
   end
 
   def update
     @order = Order.find(params[:id])
     @order.update(order_params)
+    #入金確認が取れたら自動的に製作ステータスを製作待ちに変更
+    if @order.order_status == "payment_confirmed"
+      @order.order_details.update_all(production_status: 1)
+    end
     redirect_to admin_order_path(@order)
   end
 

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,8 +1,8 @@
 class Public::ItemsController < ApplicationController
   def index
-     @items = Item.all.page(params[:page]).per(10)
-     @quantity = Item.count
-     @genres = Genre.all
+    @items = Item.all.page(params[:page]).per(10)
+    @quantity = Item.count
+    @genres = Genre.all
   end
 
   def show

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -6,13 +6,13 @@ class Public::OrdersController < ApplicationController
 
   def confirmation
     @order = Order.new(order_params)
-    @customer = current_customer
+    @cart_items = current_customer.cart_items.all
     @payment_method = @order.method_of_payment
     #会員に登録された住所
     if params[:order][:shipping_address] == "my_address"
-      @order.postal_code = @customer.postal_code
-      @order.address = @customer.address
-      @order.name = @customer.family_name + @customer.first_name
+      @order.postal_code = current_customer.postal_code
+      @order.address = current_customer.address
+      @order.name = current_customer.family_name + current_customer.first_name
     #登録済み住所から選択された住所
     elsif params[:order][:shipping_address] == "registered_address"
       @address = ShippingAddress.find(params[:order][:address_id])
@@ -28,9 +28,9 @@ class Public::OrdersController < ApplicationController
     @order.customer_id = current_customer.id
     @order.save
 
-    #@order_details = OrderDetails.new
-    #@order_details.order_id = @order.id
-    #cart_items = current_customer.cart_items.all
+    @order_details = OrderDetails.new
+    @order_details.order_id = @order.id
+    @cart_items = current_customer.cart_items.all
 
     #カート内アイテムの商品ごとにorder_detailを
     #@cart_items.each do |cart_item|

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -27,6 +27,21 @@ class Public::OrdersController < ApplicationController
     @order = Order.new(order_params)
     @order.customer_id = current_customer.id
     @order.save
+    
+    #@order_details = OrderDetails.new
+    #@order_details.order_id = @order.id
+    #cart_items = current_customer.cart_items.all
+
+    #カート内アイテムの商品ごとにorder_detailを
+    #@cart_items.each do |cart_item|
+      #@order_details.item_id = cart_item.item.id
+      #@order_details.price = cart_items.price
+      #@order_details.quantity = cart_item.quantity
+      #@order_details.save!
+    #end
+    
+    #カート内アイテムを全削除
+    #CartItem.destroy_all
     redirect_to completed_path
   end
 

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -27,7 +27,7 @@ class Public::OrdersController < ApplicationController
     @order = Order.new(order_params)
     @order.customer_id = current_customer.id
     @order.save
-    
+
     #@order_details = OrderDetails.new
     #@order_details.order_id = @order.id
     #cart_items = current_customer.cart_items.all
@@ -39,7 +39,7 @@ class Public::OrdersController < ApplicationController
       #@order_details.quantity = cart_item.quantity
       #@order_details.save!
     #end
-    
+
     #カート内アイテムを全削除
     #CartItem.destroy_all
     redirect_to completed_path
@@ -55,11 +55,11 @@ class Public::OrdersController < ApplicationController
   def show
     @order = Order.find(params[:id])
   end
-  
+
   private
   def order_params
     params.require(:order).permit(:method_of_payment, :shipping_address, :postal_code, :address, :name)
   end
 
-  
+
 end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -63,7 +63,7 @@ class Public::OrdersController < ApplicationController
   end
 
   def index
-    @orders = Order.all
+    @orders = current_customer.orders.all
   end
 
   def show

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -1,19 +1,50 @@
 class Public::OrdersController < ApplicationController
   def new
+    @order = Order.new
+    @customer = current_customer
   end
 
   def confirmation
+    @order = Order.new(order_params)
+    @customer = current_customer
+    @payment_method = @order.method_of_payment
+    #会員に登録された住所
+    if params[:order][:shipping_address] == "my_address"
+      @order.postal_code = @customer.postal_code
+      @order.address = @customer.address
+      @order.name = @customer.family_name + @customer.first_name
+    #登録済み住所から選択された住所
+    elsif params[:order][:shipping_address] == "registered_address"
+      @address = ShippingAddress.find(params[:order][:address_id])
+      @order.postal_code = @address.postal_code
+      @order.address = @address.address
+      @order.name = @address.name
+    end
+    @order.save
+  end
+
+  def create
+    @order = Order.new(order_params)
+    @order.customer_id = current_customer.id
+    @order.save
+    redirect_to completed_path
   end
 
   def completed
   end
 
   def index
+    @orders = Order.all
   end
 
   def show
+    @order = Order.find(params[:id])
   end
   
-  def create
-  end 
+  private
+  def order_params
+    params.require(:order).permit(:method_of_payment, :shipping_address, :postal_code, :address, :name)
+  end
+
+  
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,9 +2,12 @@ class Order < ApplicationRecord
   belongs_to :customer
   has_many :order_details, dependent: :destroy
   has_many :items, through: :order_details
-  
+
   validates :postal_code, presence: true, length: {maximum: 7}
   validates :address, presence: true
   validates :name, presence: true
+
+  enum method_of_payment: {credit_card: 0, transfer: 1}
+  enum shipping_address: {my_address: 0, registered_address: 1, new_address: 2}
 
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,5 +9,5 @@ class Order < ApplicationRecord
 
   enum method_of_payment: {credit_card: 0, transfer: 1}
   enum shipping_address: {my_address: 0, registered_address: 1, new_address: 2}
-
+  enum order_status: {customer_payment: 0, payment_confirmed: 1, production: 2, preparation: 3, shipped: 4}
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -1,8 +1,11 @@
 class OrderDetail < ApplicationRecord
-  
   belongs_to :order
   belongs_to :item
-  
-  enum production_status: {pending: 0, waiting_for_production: 1, working: 2, completed: 3}
+
+  enum production_status: {pending: 0, ready: 1, working: 2, completed: 3}
+
+  def subtotal
+    item.with_tax_price * quantity
+  end
 
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -1,5 +1,8 @@
 class OrderDetail < ApplicationRecord
+  
   belongs_to :order
   belongs_to :item
+  
+  enum production_status: {pending: 0, waiting_for_production: 1, working: 2, completed: 3}
 
 end

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -1,8 +1,12 @@
 class ShippingAddress < ApplicationRecord
   belongs_to :customer
-  
+
   validates :postal_code, presence: true, length: {maximum: 7}
   validates :address, presence: true
   validates :name, presence: true
+
+  def address_display #住所を〒から名前まで一行で表示する
+    '〒' + postal_code + ' ' + address + ' ' + name
+  end
 
 end

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,2 +1,27 @@
-<h1>Admin::Orders#index</h1>
-<p>Find me in app/views/admin/orders/index.html.erb</p>
+<div class="container px-4">
+  <h3 class="bg-light d-inline-block px-4 mx-5">注文履歴一覧</h3>
+
+  <div class="container row justify-content-center">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>購入日時</th>
+          <th>購入者</th>
+          <th>注文個数</th>
+          <th>注文ステータス</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @orders.each do |order| %>
+        <tr>
+          <td><%= link_to order.created_at.strftime('%Y/%m/%d %H:%M:%S'), admin_order_path(order) %></td>
+          <td><%= order.customer.family_name + order.customer.first_name %>
+          <td>1<!-- order.items.count --></td>
+          <td><%= order.order_status_i18n %></td>
+        </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <%= paginate @orders %>
+  </div>
+</div>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -16,7 +16,7 @@
         <tr>
           <td><%= link_to order.created_at.strftime('%Y/%m/%d %H:%M:%S'), admin_order_path(order) %></td>
           <td><%= order.customer.family_name + order.customer.first_name %>
-          <td>1<!-- order.items.count --></td>
+          <td><%= order.items.count %></td>
           <td><%= order.order_status_i18n %></td>
         </tr>
         <% end %>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -64,7 +64,7 @@
                   "着手不可": OrderDetail.production_statuses.key(0),
                   "製作待ち": OrderDetail.production_statuses.key(1),
                   "製作中": OrderDetail.production_statuses.key(2),
-                  "製作官僚": OrderDetail.production_statuses.key(3),
+                  "製作完了": OrderDetail.production_statuses.key(3),
                   }  %>
                 <%= f.submit "更新", class: "btn btn-success ml-3" %>
               <% end %>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -52,15 +52,15 @@
           </tr>
         </thead>
         <tbody>
-          <!-- @order.items.each do |item| %> -->
+          <% @order.order_details.each do |order_detail| %>
           <tr>
-            <td>洋ナシのチーズタルト</td>
-            <td>1,320</td>
-            <td>1</td>
-            <td>1,320</td>
+            <td><%= order_detail.item.name %></td>
+            <td><%= order_detail.item.with_tax_price %></td>
+            <td><%= order_detail.quantity %></td>
+            <td><%= order_detail.subtotal %></td>
             <td>
-              <%= form_with model: @order_detail, url: admin_order_detail_path, method: :patch do |f|%>
-                <%= f.select :order_status, {
+              <%= form_with model: order_detail, url: admin_order_detail_path(order_detail.id), method: :patch do |f|%>
+                <%= f.select :production_status, {
                   "着手不可": OrderDetail.production_statuses.key(0),
                   "製作待ち": OrderDetail.production_statuses.key(1),
                   "製作中": OrderDetail.production_statuses.key(2),
@@ -70,22 +70,22 @@
               <% end %>
             </td>
           </tr>
-          <!-- end -->
+          <% end %>
         </tbody>
       </table>
       <div class="col-3">
         <table class="table table-borderless">
           <tr>
             <th>商品合計</th>
-            <td> 円</td>
+            <td class="text-right"><%= @total %> 円</td>
           </tr>
           <tr>
             <th>送料</th>
-            <td> 円</td>
+            <td class="text-right"><%= @order.shipping_fee %> 円</td>
           </tr>
           <tr>
             <th>請求金額合計</th>
-            <th> 円</th>
+            <th class="text-right"><%= @order.billing_amount %> 円</th>
           </tr>
         </table>
       </div>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,2 +1,84 @@
-<h1>Admin::Orders#show</h1>
-<p>Find me in app/views/admin/orders/show.html.erb</p>
+<div class="container px-4">
+  <h3 class="bg-light d-inline-block px-4 mx-5">注文履歴詳細</h3>
+
+  <div class="container">
+    <table class="table table-borderless">
+      <tbody>
+        <tr>
+          <th class="col-2">購入者</th>
+          <td><%= @order_customer_name %></td>
+        </tr>
+        <tr>
+          <th>注文日</th>
+          <td><%= @order.created_at.strftime('%Y/%m/%d') %></td>
+        </tr>
+        <tr>
+          <th>配送先</th>
+          <td>〒<%= @order.postal_code %> <%= @order.address %><br>
+          <%= @order.name %>
+          </td>
+        </tr>
+        <tr>
+          <th>支払方法</th>
+          <td><%= @order.method_of_payment_i18n %></td>
+        </tr>
+        <tr>
+          <th>注文ステータス</th>
+          <td>
+            <%= form_with model: @order, url: admin_order_path(@order), method: :patch do |f|%>
+              <%= f.select :order_status, {
+                "入金待ち": Order.order_statuses.key(0),
+                "入金確認": Order.order_statuses.key(1),
+                "製作中":  Order.order_statuses.key(2),
+                "発送準備":  Order.order_statuses.key(3),
+                "発送済み":  Order.order_statuses.key(4)
+                }  %>
+              <%= f.submit "更新", class: "btn btn-success ml-3" %>
+            <% end %>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="row">
+      <table class="table col-8">
+        <thead>
+          <tr class="bg-light">
+            <th>商品名</th>
+            <th>単価(税込)</th>
+            <th>数量</th>
+            <th>小計</th>
+            <th>製作ステータス</th>
+          </tr>
+        </thead>
+        <tbody>
+          <!-- @order.items.each do |item| %> -->
+          <tr>
+            <td>洋ナシのチーズタルト</td>
+            <td>1,320</td>
+            <td>1</td>
+            <td>1,320</td>
+            <td>着手不可 更新</td>
+          </tr>
+          <!-- end -->
+        </tbody>
+      </table>
+      <div class="col-3">
+        <table class="table table-borderless">
+          <tr>
+            <th>商品合計</th>
+            <td> 円</td>
+          </tr>
+          <tr>
+            <th>送料</th>
+            <td> 円</td>
+          </tr>
+          <tr>
+            <th>請求金額合計</th>
+            <th> 円</th>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -58,7 +58,17 @@
             <td>1,320</td>
             <td>1</td>
             <td>1,320</td>
-            <td>着手不可 更新</td>
+            <td>
+              <%= form_with model: @order_detail, url: admin_order_detail_path, method: :patch do |f|%>
+                <%= f.select :order_status, {
+                  "着手不可": OrderDetail.production_statuses.key(0),
+                  "製作待ち": OrderDetail.production_statuses.key(1),
+                  "製作中": OrderDetail.production_statuses.key(2),
+                  "製作官僚": OrderDetail.production_statuses.key(3),
+                  }  %>
+                <%= f.submit "更新", class: "btn btn-success ml-3" %>
+              <% end %>
+            </td>
           </tr>
           <!-- end -->
         </tbody>

--- a/app/views/public/orders/completed.html.erb
+++ b/app/views/public/orders/completed.html.erb
@@ -1,2 +1,3 @@
-<h1>Public::Orders#completed</h1>
-<p>Find me in app/views/public/orders/completed.html.erb</p>
+<div class="container min-vw-100 d-flex align-items-center justify-content-center" style="height:600px;">
+  <h2>ご注文ありがとうございました！</h2>
+</div>

--- a/app/views/public/orders/confirmation.html.erb
+++ b/app/views/public/orders/confirmation.html.erb
@@ -14,18 +14,14 @@
           </tr>
         </thead>
         <tbody>
+          <% @cart_items.each do |cart_item| %>
           <tr>
-            <th>チョコバナナミルフィーユ</th>
-            <td>1,100</td>
-            <td>1</td>
-            <td>1,100</td>
+            <th><%= cart_item.item.name %></th>
+            <td><%= cart_item.item.with_tax_price %></td>
+            <td><%= cart_item.quantity %></td>
+            <td><%= cart_item.subtotal %></td>
           </tr>
-          <tr>
-            <th>チーズタルト</th>
-            <td>1,100</td>
-            <td>1</td>
-            <td>1,100</td>
-          </tr>
+          <% end %>
         </tbody>
       </table>
       <table class="price col-3 table table-bordered ml-5">
@@ -33,15 +29,15 @@
           <tr>
             <tr>
               <td class="bg-light">送料</td>
-              <td>800</td>
+              <td><%= @order.shipping_fee %> 円</td>
             </tr>
             <tr>
               <td class="bg-light">商品合計</td>
-              <td>1,760</td>
+              <td><%= @cart_items_total %> 円</td>
             </tr>
             <tr>
               <td class="bg-light">請求金額</td>
-              <td>2,560</td>
+              <td><%= @order.billing_amount %> 円</td>
             </tr>
           </tr>
         </tbody>
@@ -62,7 +58,6 @@
       <p>〒<%= @order.postal_code %> <%= @order.address %><br>
         <%= @order.name %>
     </div>
-
     <div class="d-flex justify-content-center">
         <%= f.submit "注文を確定する", class: "btn btn-success" %>
     </div>

--- a/app/views/public/orders/confirmation.html.erb
+++ b/app/views/public/orders/confirmation.html.erb
@@ -1,2 +1,71 @@
-<h1>Public::Orders#confirmation</h1>
-<p>Find me in app/views/public/orders/confirmation.html.erb</p>
+<div class="container px-4">
+  <h3 class="bg-light d-inline-block px-4 mx-5">注文情報確認</h3>
+
+  <div class="container">
+    <%= form_with model: @order do |f| %>
+    <div class="row mb-4">
+      <table class="items col-8 table table-bordered">
+        <thead>
+          <tr class="bg-light">
+            <td col="4">商品名</td>
+            <td>単価(税込)</td>
+            <td>数量　　</td>
+            <td>小計　　</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>チョコバナナミルフィーユ</th>
+            <td>1,100</td>
+            <td>1</td>
+            <td>1,100</td>
+          </tr>
+          <tr>
+            <th>チーズタルト</th>
+            <td>1,100</td>
+            <td>1</td>
+            <td>1,100</td>
+          </tr>
+        </tbody>
+      </table>
+      <table class="price col-3 table table-bordered ml-5">
+        <tbody>
+          <tr>
+            <tr>
+              <td class="bg-light">送料</td>
+              <td>800</td>
+            </tr>
+            <tr>
+              <td class="bg-light">商品合計</td>
+              <td>1,760</td>
+            </tr>
+            <tr>
+              <td class="bg-light">請求金額</td>
+              <td>2,560</td>
+            </tr>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="row mb-4">
+      <h4 class="font-weight-bolder mr-5">支払方法</h4>
+      <h5><%= f.hidden_field :method_of_payment, value: @order.method_of_payment %>
+        <%= @order.method_of_payment_i18n %></h5>
+    </div>
+
+    <div class="row mb-4">
+      <h4 class="font-weight-bolder mr-5">お届け先</h4>
+      <%= f.hidden_field :postal_code, value: @order.postal_code %>
+      <%= f.hidden_field :address, value: @order.address %>
+      <%= f.hidden_field :name, value: @order.name %>
+      <p>〒<%= @order.postal_code %> <%= @order.address %><br>
+        <%= @order.name %>
+    </div>
+
+    <div class="d-flex justify-content-center">
+        <%= f.submit "注文を確定する", class: "btn btn-success" %>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -2,37 +2,41 @@
   <h3 class="bg-light d-inline-block px-4 mx-5">注文履歴一覧</h3>
 
   <div class="container my-3">
-    <table class="table table-bordered">
-      <thead>
-        <tr>
-          <td>注文日</td>
-          <td class="col-5">配送先</td>
-          <td class="col-2">注文商品</td>
-          <td>支払金額</td>
-          <td>ステータス</td>
-          <td>注文詳細</td>
-        </tr>
-      </thead>
-      <tbody>
-        <% @orders.each do |order| %>
+    <% if @orders.any? %>
+      <table class="table table-bordered">
+        <thead>
           <tr>
-            <td class="align-middle"><%= order.created_at.strftime('%Y/%m/%d')%></td>
-            <td>〒<%= order.postal_code%><br>
-                <%= order.address %><br>
-                <%= order.name %>
-            </td>
-            <td class="align-middle">
-            <!-- order.items.each do |item| -->
-            <!-- li item.name -->
-            イチゴのショートケーキ<br>
-            ガトーショコラ
-            </td>
-            <td class="align-middle">2.300円<!-- order.billing_amount --></td>
-            <td class="align-middle"><%= order.order_status_i18n %></td>
-            <td class="align-middle"><%= link_to "表示する", order_path(order), class: "btn btn-sm btn-primary" %></td>
+            <td>注文日</td>
+            <td class="col-5">配送先</td>
+            <td class="col-2">注文商品</td>
+            <td>支払金額</td>
+            <td>ステータス</td>
+            <td>注文詳細</td>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          <% @orders.each do |order| %>
+            <tr>
+              <td class="align-middle"><%= order.created_at.strftime('%Y/%m/%d')%></td>
+              <td>〒<%= order.postal_code%><br>
+                  <%= order.address %><br>
+                  <%= order.name %>
+              </td>
+              <td class="align-middle">
+              <!-- order.items.each do |item| -->
+              <!-- li item.name -->
+              イチゴのショートケーキ<br>
+              ガトーショコラ
+              </td>
+              <td class="align-middle">2.300円<!-- order.billing_amount --></td>
+              <td class="align-middle"><%= order.order_status_i18n %></td>
+              <td class="align-middle"><%= link_to "表示する", order_path(order), class: "btn btn-sm btn-primary" %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <h3 class="text-center">注文はありません</h3>
+    <% end %>
   </div>
 </div>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -1,2 +1,38 @@
-<h1>Public::Orders#index</h1>
-<p>Find me in app/views/public/orders/index.html.erb</p>
+<div class="container px-4">
+  <h3 class="bg-light d-inline-block px-4 mx-5">注文履歴一覧</h3>
+
+  <div class="container my-3">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <td>注文日</td>
+          <td class="col-5">配送先</td>
+          <td class="col-2">注文商品</td>
+          <td>支払金額</td>
+          <td>ステータス</td>
+          <td>注文詳細</td>
+        </tr>
+      </thead>
+      <tbody>
+        <% @orders.each do |order| %>
+          <tr>
+            <td class="align-middle"><%= order.created_at.strftime('%Y/%m/%d')%></td>
+            <td>〒<%= order.postal_code%><br>
+                <%= order.address %><br>
+                <%= order.name %>
+            </td>
+            <td class="align-middle">
+            <!-- order.items.each do |item| -->
+            <!-- li item.name -->
+            イチゴのショートケーキ<br>
+            ガトーショコラ
+            </td>
+            <td class="align-middle">2.300円<!-- order.billing_amount --></td>
+            <td class="align-middle"><%= order.order_status_i18n %></td>
+            <td class="align-middle"><%= link_to "表示する", order_path(order), class: "btn btn-sm btn-primary" %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -23,12 +23,13 @@
                   <%= order.name %>
               </td>
               <td class="align-middle">
-              <!-- order.items.each do |item| -->
-              <!-- li item.name -->
-              イチゴのショートケーキ<br>
-              ガトーショコラ
+                <ul>
+                  <% order.items.each do |item| %>
+                    <li style="list-style: none;"><%= item.name %></li>
+                  <% end %>
+                </ul>
               </td>
-              <td class="align-middle">2.300円<!-- order.billing_amount --></td>
+              <td class="align-middle"><%= order.billing_amount %></td>
               <td class="align-middle"><%= order.order_status_i18n %></td>
               <td class="align-middle"><%= link_to "表示する", order_path(order), class: "btn btn-sm btn-primary" %></td>
             </tr>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -23,7 +23,7 @@
 
       <!--会員情報に登録されている住所-->
       <div class="form">
-        <%= f.radio_button :shipping_address, Order.shipping_addresses.key(0) %>
+        <%= f.radio_button :shipping_address, Order.shipping_addresses.key(0), checked: "checked" %>
         <%= f.label :shipping_address, Order.shipping_addresses_i18n[:my_address] %><br>
         <p class="ml-4">〒<%= @customer.postal_code %> <%= @customer.address %><br>
         <%= @customer.family_name %><%= @customer.first_name %>
@@ -35,7 +35,11 @@
         <%= f.radio_button :shipping_address, Order.shipping_addresses.key(1) %>
         <%= f.label :shipping_address, Order.shipping_addresses_i18n[:registered_address] %>
         <div class="form ml-4">
-          <%= f.select :address_id, options_from_collection_for_select(ShippingAddress.all, :id, :address_display) %>
+          <% if @customer.shipping_addresses.any? %>
+            <%= f.select :address_id, options_from_collection_for_select(ShippingAddress.all, :id, :address_display) %>
+          <% else %>
+            <p>　登録済み住所はありません</p>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -1,2 +1,81 @@
-<h1>Public::Orders#new</h1>
-<p>Find me in app/views/public/orders/new.html.erb</p>
+<div class="container px-4">
+  <h3 class="bg-light d-inline-block px-4 mx-5">注文情報入力</h3>
+
+  <div class="container my-4">
+
+    <%= form_with model: @order, url: confirmation_path, method: :post do |f|%>
+
+    <h4 class="font-weight-bolder">支払方法</h4>
+    <div class="payment_method ml-5">
+      <div class="form">
+        <%= f.radio_button :method_of_payment, Order.method_of_payments.key(0) %>
+        <%= f.label :method_of_payment, Order.method_of_payments_i18n[:credit_card] %>
+      </div>
+      <div class="form">
+        <%= f.radio_button :method_of_payment, Order.method_of_payments.key(1) %>
+        <%= f.label :method_of_payment, Order.method_of_payments_i18n[:transfer] %>
+      </div>
+    </div>
+
+
+    <h4 class="font-weight-bolder mt-3">お届け先</h4>
+    <div class="shipping_address ml-5">
+
+      <!--会員情報に登録されている住所-->
+      <div class="form">
+        <%= f.radio_button :shipping_address, Order.shipping_addresses.key(0) %>
+        <%= f.label :shipping_address, Order.shipping_addresses_i18n[:my_address] %><br>
+        <p class="ml-4">〒<%= @customer.postal_code %> <%= @customer.address %><br>
+        <%= @customer.family_name %><%= @customer.first_name %>
+        </p>
+      </div>
+
+      <!--登録済みの住所を選択する-->
+      <div class="form mt-3">
+        <%= f.radio_button :shipping_address, Order.shipping_addresses.key(1) %>
+        <%= f.label :shipping_address, Order.shipping_addresses_i18n[:registered_address] %>
+        <div class="form ml-4">
+          <%= f.select :address_id, options_from_collection_for_select(ShippingAddress.all, :id, :address_display) %>
+        </div>
+      </div>
+
+      <!--新しく住所を入力する-->
+      <div class="form mt-3">
+        <%= f.radio_button :shipping_address, Order.shipping_addresses.key(2) %>
+        <%= f.label :shipping_address, Order.shipping_addresses_i18n[:new_address] %>
+
+        <div class="form-group ml-4 row">
+          <label for="postal_code" class="col-3 col-form-label">郵便番号(ハイフンなし)</label>
+          <div class="col-5">
+            <%= f.text_field :postal_code, class:"form-control mx-2", "placeholder" => "0000000" %>
+          </div>
+        </div>
+
+        <div class="form-group ml-4 row">
+          <label for="address" class="col-3 col-form-label">住所</label>
+          <div class="col-9">
+            <%= f.text_field :address, class:"form-control mx-2", "placeholder" => "東京都渋谷区代々木神園町0-0" %>
+          </div>
+        </div>
+
+        <div class="form-group ml-4 row">
+          <label for="name" class="col-3 col-form-label">宛名</label>
+          <div class="col-5">
+            <%= f.text_field :name, class:"form-control mx-2", "placeholder" => "令和道子" %>
+          </div>
+        </div>
+      </div>
+
+    </div>
+    <div class="actions d-flex justify-content-center">
+        <%= f.submit "確認画面へ進む", class: "btn btn-primary" %>
+    </div>
+
+    <% end %>
+
+  </div>
+</div>
+
+
+
+

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -33,20 +33,18 @@
         <h5>請求情報</h5>
         <table class="price table table-bordered">
           <tbody>
-            <tr>
               <tr>
                 <td class="col-5 bg-light">商品合計</td>
-                <td>1,500</td>
+                <td><%= @total %></td>
               </tr>
               <tr>
                 <td class="bg-light">配送料</td>
-                <td>800</td>
+                <td><%= @order.shipping_fee %></td>
               </tr>
               <tr>
                 <td class="bg-light">ご請求額</td>
-                <td>2,560</td>
+                <td><%= @order.billing_amount %></td>
               </tr>
-            </tr>
           </tbody>
         </table>
       </div>
@@ -64,18 +62,14 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>チョコバナナミルフィーユ</th>
-            <td>1,100</td>
-            <td>1</td>
-            <td>1,100</td>
-          </tr>
-          <tr>
-            <td>チーズタルト</th>
-            <td>1,100</td>
-            <td>1</td>
-            <td>1,100</td>
-          </tr>
+          <% @order.order_details.each do |order_detail| %>
+            <tr>
+              <td><%= order_detail.item.name %></th>
+              <td><%= order_detail.item.with_tax_price %></td>
+              <td><%= order_detail.quantity %></td>
+              <td><%= order_detail.item.with_tax_price * order_detail.quantity %></td>
+            </tr>
+          <% end %>
         </tbody>
       </table>
       </div>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -1,2 +1,84 @@
-<h1>Public::Orders#show</h1>
-<p>Find me in app/views/public/orders/show.html.erb</p>
+<div class="container px-4">
+  <h3 class="bg-light d-inline-block px-4 mx-5">注文履歴詳細</h3>
+
+  <div class="container my-5">
+    <div class="row mb-4">
+      <div class="order_details col-7">
+        <h5>注文情報</h5>
+        <table class="items table table-bordered">
+          <tbody>
+            <tr>
+              <td class="col-3 bg-light">注文日</td>
+              <td><%= @order.created_at.strftime('%Y/%m/%d') %></td>
+            </tr>
+            <tr>
+              <td class="bg-light">配送先</td>
+            <td>〒<%= @order.postal_code %><br>
+              <%= @order.address %><br>
+              <%= @order.name %>
+              </td>
+            </tr>
+            <tr>
+              <td class="bg-light">支払方法</td>
+              <td><%= @order.method_of_payment_i18n %></td>
+            </tr>
+          <tr>
+              <td class="bg-light">ステータス</td>
+              <td><%= @order.order_status_i18n %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="order_bills col-4 ml-5">
+        <h5>請求情報</h5>
+        <table class="price table table-bordered">
+          <tbody>
+            <tr>
+              <tr>
+                <td class="col-5 bg-light">商品合計</td>
+                <td>1,500</td>
+              </tr>
+              <tr>
+                <td class="bg-light">配送料</td>
+                <td>800</td>
+              </tr>
+              <tr>
+                <td class="bg-light">ご請求額</td>
+                <td>2,560</td>
+              </tr>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="row">
+    <div class="order_items col-10">
+      <h5>注文内容</h5>
+      <table class="items table table-bordered">
+        <thead>
+          <tr class="bg-light">
+            <td class="col-4">商品名</td>
+            <td>単価(税込)</td>
+            <td>数量　　</td>
+            <td>小計　　</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>チョコバナナミルフィーユ</th>
+            <td>1,100</td>
+            <td>1</td>
+            <td>1,100</td>
+          </tr>
+          <tr>
+            <td>チーズタルト</th>
+            <td>1,100</td>
+            <td>1</td>
+            <td>1,100</td>
+          </tr>
+        </tbody>
+      </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,10 @@ module NaganoCake
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
+
+    #enum日本語化
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/*.yml').to_s]
+
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,3 +16,9 @@
           production: "製作中"
           preparation: "発送準備中"
           shipped: "発送済み"
+
+      production_status:
+          pending: "着手不可"
+          waiting_for_production: "製作待ち"
+          working: "製作中"
+          completed: "製作完了"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,11 @@
+ ja:
+    enums:
+      order:
+        method_of_payment:
+          credit_card: "クレジットカード"
+          transfer: "銀行振込"
+
+        shipping_address:
+          my_address:   "ご自身の住所"
+          registered_address: "登録済住所から"
+          new_address: "新しいお届け先"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,3 +9,10 @@
           my_address:   "ご自身の住所"
           registered_address: "登録済住所から"
           new_address: "新しいお届け先"
+
+        order_status:
+          customer_payment: "入金待ち"
+          payment_confirmed: "入金確認"
+          production: "製作中"
+          preparation: "発送準備中"
+          shipped: "発送済み"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,6 @@
 
       production_status:
           pending: "着手不可"
-          waiting_for_production: "製作待ち"
+          ready: "製作待ち"
           working: "製作中"
           completed: "製作完了"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
 
     get 'orders/completed', as: 'completed'
     post 'orders/confirmation', as: 'confirmation'
-    resources :orders, only: [:new, :create, :indexm, :show]
+    resources :orders, only: [:new, :create, :index, :show]
   end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,9 +40,10 @@ Rails.application.routes.draw do
     resources :cart_items, only: [:index, :create, :update, :destroy]
 
 
-    resources :orders, only: [:new, :create, :index, :show]
+    resources :orders, only: [:new, :create, :index]
     get 'orders/completed', as: 'completed'
     post 'orders/confirmation', as: 'confirmation'
+    get 'orders/:id' => "orders#show", as: 'order'
   end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,10 +40,9 @@ Rails.application.routes.draw do
     resources :cart_items, only: [:index, :create, :update, :destroy]
 
 
-    resources :orders, only: [:new, :create, :index]
     get 'orders/completed', as: 'completed'
     post 'orders/confirmation', as: 'confirmation'
-    get 'orders/:id' => "orders#show", as: 'order'
+    resources :orders, only: [:new, :create, :indexm, :show]
   end
 
 


### PR DESCRIPTION
修正した問題点
① 注文情報入力画面のお届け先のradioボタンが遷移してすぐだとどれも選択されていない状態でそのまま確認画面へ進むことができてしまっているので、支払い方法のようにデフォルトでどれか選択されている状態にするか、何も入力されていない状態で確認画面へ進むボタンが押された場合はエラーメッセージを出して先の画面に進めないようにした方がいいと思いました。
　→最初のradioボタン(自分の住所)にcheckedをつけ、デフォルトで設定されるように修正しました。これで選択されていない状態で確認画面に進むことはないはずです。

② 同じページで登録済み住所が登録されていない時プルダウンのボタンだけが表示されているのでもし登録済み住所が登録されていない場合、「登録済み住所はありません。」などの文をif分などで表示させた方が見た目としてはいいのかなと思います！
　→登録済み住所がない場合はプルダウンが表示されないようにし、代わりにメッセージが表示されるように修正しました。

③ public/orders.controller.rbのindexアクションでhttps://github.com/orders = Order.allと記述がありますが、これだと全ての顧客の注文履歴が見れてしまうのでhttps://github.com/orders = current_customer.ordersとかに修正した方がいいと思います。
　→指摘通り修正しました。


④ admin/orders/index.html.erbファイルの注文個数コメントアウトにせずそのまま表示させても問題ないと思うんですけど理由ってありますか？
　→単なる見落としでした。コメントアウトをなくし、正常に表示されるようにしました。

修正点は以上です。確認お願いします。